### PR TITLE
Switch physfs to the commit as it exists in the icculus repo instead …

### DIFF
--- a/packages/games/emulators/solarus/physfs/package.mk
+++ b/packages/games/emulators/solarus/physfs/package.mk
@@ -2,10 +2,10 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="physfs"
-PKG_VERSION="610a844fa3d003fc8501dd2b0a1ce13d077a38b6"
+PKG_VERSION="009be5ab20b0e590c68039415a0768e6d4651808"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
-PKG_SITE="https://github.com/criptych/physfs"
+PKG_SITE="https://github.com/icculus/physfs"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain glm"
 PKG_SHORTDESC="PhysicsFS; a portable, flexible file i/o abstraction."


### PR DESCRIPTION
…of the fork.  Likely the fork was rebased from the main repo after the referenced commit was merged causing the commit to "dissapear"